### PR TITLE
Use double quotes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'pronto-standardrb'
+gem "pronto-standardrb"
 ```
 
 And then execute:


### PR DESCRIPTION
The standard library force to use double quotes. The example in Readme used single quotes style, that would probably the first lint error.