### PR TITLE
Use pry only for development

### DIFF
--- a/lib/pronto/standardrb.rb
+++ b/lib/pronto/standardrb.rb
@@ -1,7 +1,6 @@
 require "pronto/standardrb/version"
 require "pronto"
 require "rubocop"
-require "pry"
 require "standard"
 
 module Pronto


### PR DESCRIPTION
There is no gem dependicies for `pry`, but it required in the main library.

When include pronto-standard there is an error:

```
bundle/ruby/2.6.0/gems/pronto-standardrb-0.1.1/lib/pronto/standardrb.rb:4:in `require': cannot load such file -- pry (LoadError)
```