### PR TITLE
Respect files excluded in the configuration

### DIFF
--- a/lib/pronto/standardrb.rb
+++ b/lib/pronto/standardrb.rb
@@ -6,8 +6,9 @@ require "standard"
 module Pronto
   class Standardrb < Runner
     def run
-      ruby_patches
-        .flat_map do |patch|
+      ruby_patches.flat_map do |patch|
+        next [] unless valid?(patch)
+
         offenses(patch).flat_map do |offense|
           patch
             .added_lines
@@ -28,6 +29,12 @@ module Pronto
     end
 
     private
+
+    def valid?(patch)
+      return false if rubocop_config(patch).file_to_exclude?(path(patch))
+
+      rubocop_config(patch).file_to_include?(path(patch))
+    end
 
     def processed_source(patch)
       processed_source = ::RuboCop::ProcessedSource.from_file(

--- a/spec/pronto/standardrb_spec.rb
+++ b/spec/pronto/standardrb_spec.rb
@@ -28,6 +28,10 @@ module Pronto
       context "patches with smells" do
         include_context "test repo"
 
+        before do
+          allow(standardrb).to receive(:valid?).and_return(true)
+        end
+
         let(:patches) { repo.diff("2dec0010") }
 
         its(:count) { should == 2 }


### PR DESCRIPTION
Check if file has been excluded in the configuration file before running cops on it.