### PR TITLE
Load project .standard.yml configuration file

### DIFF
--- a/lib/pronto/standardrb.rb
+++ b/lib/pronto/standardrb.rb
@@ -48,7 +48,8 @@ module Pronto
 
     def offenses(patch)
       team(patch)
-        .inspect_file(processed_source(patch))
+        .investigate(processed_source(patch))
+        .offenses
         .sort
         .reject(&:disabled?)
     end
@@ -58,11 +59,11 @@ module Pronto
     end
 
     def team(patch)
-      @team ||= ::RuboCop::Cop::Team.new(registry, rubocop_config(patch))
+      @team ||= ::RuboCop::Cop::Team.mobilize(registry, rubocop_config(patch))
     end
 
     def registry
-      @registry ||= ::RuboCop::Cop::Registry.new(RuboCop::Cop::Cop.all)
+      @registry ||= ::RuboCop::Cop::Registry.global
     end
 
     def level(severity)

--- a/lib/pronto/standardrb.rb
+++ b/lib/pronto/standardrb.rb
@@ -19,7 +19,8 @@ module Pronto
 
     def rubocop_config(patch)
       builds_config = Standard::BuildsConfig.new
-      config = builds_config.call([])
+      # Pass the file path so Standard can find .standard.yml in the project
+      config = builds_config.call([path(patch)])
 
       @rubocop_config ||= begin
         store = config.rubocop_config_store

--- a/pronto-standardrb.gemspec
+++ b/pronto-standardrb.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "pronto"
   spec.add_runtime_dependency "rubocop"
   spec.add_runtime_dependency "standard"
+  spec.add_runtime_dependency "base64"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The gem was not loading the project's .standard.yml file, making it impossible to use standard plugins like standard-rails. This was because Standard::BuildsConfig.call([]) was being called with an empty array, which didn't provide any context about where to look for the config file.

By passing the file path to BuildsConfig.call(), Standard can now properly locate and load the .standard.yml file in the project root, enabling plugin support and custom configurations.

Fix #3 