### PR TITLE
Fix RuboCop/StandardRB deprecation warnings

### DIFF
--- a/lib/pronto/standardrb.rb
+++ b/lib/pronto/standardrb.rb
@@ -47,7 +47,8 @@ module Pronto
 
     def offenses(patch)
       team(patch)
-        .inspect_file(processed_source(patch))
+        .investigate(processed_source(patch))
+        .offenses
         .sort
         .reject(&:disabled?)
     end
@@ -57,11 +58,11 @@ module Pronto
     end
 
     def team(patch)
-      @team ||= ::RuboCop::Cop::Team.new(registry, rubocop_config(patch))
+      @team ||= ::RuboCop::Cop::Team.mobilize(registry, rubocop_config(patch))
     end
 
     def registry
-      @registry ||= ::RuboCop::Cop::Registry.new(RuboCop::Cop::Cop.all)
+      @registry ||= ::RuboCop::Cop::Registry.global
     end
 
     def level(severity)


### PR DESCRIPTION
Replace deprecated methods with their modern equivalents:
- Use Registry.global instead of Registry.new(Cop.all)
- Use Team.mobilize instead of Team.new
- Use investigate instead of inspect_file