### PR TITLE
Include base64 gem as runtime dependency

### DIFF
--- a/pronto-standardrb.gemspec
+++ b/pronto-standardrb.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "pronto"
   spec.add_runtime_dependency "rubocop"
   spec.add_runtime_dependency "standard"
+  spec.add_runtime_dependency "base64"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Since Ruby 3.4 the gem has extracted out of core gems and need to be explicited required